### PR TITLE
Added support for multiple developer/designer profiles in about section

### DIFF
--- a/app/src/main/java/com/afollestad/polar/adapters/AboutAdapter.java
+++ b/app/src/main/java/com/afollestad/polar/adapters/AboutAdapter.java
@@ -9,9 +9,11 @@ import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -53,8 +55,15 @@ public class AboutAdapter extends RecyclerView.Adapter<AboutAdapter.MainViewHold
         mDescriptions = context.getResources().getStringArray(R.array.about_descriptions);
         mImages = context.getResources().getStringArray(R.array.about_images);
         mCovers = context.getResources().getStringArray(R.array.about_covers);
+        mDevButtonTitles = context.getResources().getStringArray(R.array.about_button_1_titles);
+        mDevButtonLinks = context.getResources().getStringArray(R.array.about_button_1_links);
+        mDevButtonTitles2 = context.getResources().getStringArray(R.array.about_button_2_titles);
+        mDevButtonLinks2 = context.getResources().getStringArray(R.array.about_button_2_links);
         mOptionCb = cb;
         mOptionsEnabled = Config.get().feedbackEnabled() || Config.get().donationEnabled();
+        mItemAidan = mTitles.length -3;
+        mItemTom = mTitles.length -2;
+        mItemDaniel = mTitles.length-1;
     }
 
     private final Context mContext;
@@ -62,8 +71,16 @@ public class AboutAdapter extends RecyclerView.Adapter<AboutAdapter.MainViewHold
     private final String[] mDescriptions;
     private final String[] mImages;
     private final String[] mCovers;
+    private final String[] mDevButtonTitles;
+    private final String[] mDevButtonLinks;
+    private final String[] mDevButtonTitles2;
+    private final String[] mDevButtonLinks2;
     private final OptionsClickListener mOptionCb;
     private final boolean mOptionsEnabled;
+    // saving values in case there's more than one dev
+    private int mItemAidan;
+    private final int mItemTom;
+    private final int mItemDaniel;
 
     public static class MainViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
@@ -74,6 +91,8 @@ public class AboutAdapter extends RecyclerView.Adapter<AboutAdapter.MainViewHold
             title = ButterKnife.findById(itemView, R.id.title);
             description = ButterKnife.findById(itemView, R.id.description);
             badges = ButterKnife.findById(itemView, R.id.badgesFrame);
+            leftButton = ButterKnife.findById(itemView, R.id.badgeButtonLeft);
+            rightButton = ButterKnife.findById(itemView, R.id.badgeButtonRight);
 
             feedbackButton = ButterKnife.findById(itemView, R.id.feedbackButton);
             feedbackImage = ButterKnife.findById(itemView, R.id.feedbackImage);
@@ -96,6 +115,8 @@ public class AboutAdapter extends RecyclerView.Adapter<AboutAdapter.MainViewHold
         final ImageView feedbackImage;
         final View donateButton;
         final ImageView donateImage;
+        final Button leftButton;
+        final Button rightButton;
         private final OptionsClickListener mOptionsCb;
 
         @Override
@@ -130,27 +151,18 @@ public class AboutAdapter extends RecyclerView.Adapter<AboutAdapter.MainViewHold
     @Override
     public MainViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         @LayoutRes
-        int layoutRes;
-        // Other config
-        switch (viewType) {
-            case -1:
-                layoutRes = R.layout.list_item_about_options;
-                break;
-            case 1:
-                layoutRes = R.layout.list_item_about_aidan;
-                break;
-            case 2:
-                layoutRes = R.layout.list_item_about_tom;
-                break;
-            case 3:
-                layoutRes = R.layout.list_item_about_daniel;
-                break;
-            default:
-                layoutRes = R.layout.list_item_about_dev;
-                break;
-        }
+        int layoutRes = getLayoutResourceForViewType(viewType);
         final View v = LayoutInflater.from(parent.getContext()).inflate(layoutRes, parent, false);
         return new MainViewHolder(v, mOptionCb);
+    }
+
+    @LayoutRes
+    private int getLayoutResourceForViewType(int viewType) {
+        if(viewType == -1) return R.layout.list_item_about_options;
+        else if(viewType == mItemAidan) return R.layout.list_item_about_aidan;
+        else if(viewType == mItemTom) return R.layout.list_item_about_tom;
+        else if(viewType == mItemDaniel) return R.layout.list_item_about_daniel;
+        else return R.layout.list_item_about_dev;
     }
 
     @Override
@@ -183,6 +195,13 @@ public class AboutAdapter extends RecyclerView.Adapter<AboutAdapter.MainViewHold
         holder.title.setText(mTitles[index]);
         holder.description.setText(Html.fromHtml(mDescriptions[index]));
         holder.description.setMovementMethod(LinkMovementMethod.getInstance());
+
+        if(index != mItemAidan && index != mItemTom && index != mItemDaniel) {
+            holder.leftButton.setText(mDevButtonTitles[index]);
+            holder.leftButton.setTag(mDevButtonLinks[index]);
+            holder.rightButton.setText(mDevButtonTitles2[index]);
+            holder.rightButton.setTag(mDevButtonLinks2[index]);
+        }
 
         Glide.with(mContext)
                 .load(mCovers[index])

--- a/app/src/main/res/layout/list_item_about_dev.xml
+++ b/app/src/main/res/layout/list_item_about_dev.xml
@@ -80,21 +80,19 @@
                     android:orientation="horizontal">
 
                     <Button
+                        android:id="@+id/badgeButtonLeft"
                         style="?borderlessButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:tag="@string/about_button1_link"
-                        android:text="@string/about_button1_title"
                         android:textColor="?colorAccent" />
 
                     <Button
+                        android:id="@+id/badgeButtonRight"
                         style="?borderlessButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:tag="@string/about_button2_link"
-                        android:text="@string/about_button2_title"
                         android:textColor="?colorAccent" />
 
                 </LinearLayout>

--- a/app/src/main/res/values/dev_about.xml
+++ b/app/src/main/res/values/dev_about.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- DO NOT REMOVE THESE 4 ARRAYS. -->
-    <!-- ONLY MODIFY THE FIRST ITEM IN EACH ARRAY FOR YOURSELF, OTHERWISE TERMS ARE VIOLATED. -->
+    <!-- DO NOT REMOVE THE DEV/DESIGNERS ABOUT ITEMS, OTHERWISE TERMS ARE VIOLATED. -->
 
     <string-array name="about_images" formatted="false" tools:ignore="TypographyDashes">
         <item>https://lh3.googleusercontent.com/-0mdcClKXlgM/AAAAAAAAAAI/AAAAAAAAAAA/xgdLWeAg7pM/s120-c/photo.jpg</item>
@@ -32,12 +32,24 @@
         <item formatted="false"><![CDATA[I like playing piano, doing puzzles, &amp; making apps<br/><i>I primarily helped with animations and UI</i>]]></item>
     </string-array>
 
-    <!-- The title and link of the first button in your about card -->
-    <string name="about_button1_title">Website</string>
-    <string name="about_button1_link">http://aidanfollestad.com</string>
+    <!-- The title of the left button(s) in your about card(s) -->
+    <string-array name="about_button_1_titles">
+        <item>Website</item>
+    </string-array>
 
-    <!-- The title and link of the second button in your about card -->
-    <string name="about_button2_title">Google+</string>
-    <string name="about_button2_link">https://google.com/+AidanFollestad</string>
+    <!-- The link of the left button(s) in your about card(s) -->
+    <string-array name="about_button_1_links">
+        <item>http://aidanfollestad.com</item>
+    </string-array>
+
+    <!-- The title of the right button(s) in your about card(s) -->
+    <string-array name="about_button_2_titles">
+        <item>Google+ 1</item>
+    </string-array>
+
+    <!-- The link of the right button(s) in your about card(s) -->
+    <string-array name="about_button_2_links">
+        <item>https://google.com/+AidanFollestad</item>
+    </string-array>
 
 </resources>


### PR DESCRIPTION
I've removed the static single-dev about item and added support for the possibility to add multiple additional about items to the about section (as requested in #50 )

To add (more) pages to the about section you have to edit the `dev_about .xml` as usual.
There are 4 new arrays now, two for the left button in the about card (text & link) and two for the right button in the about card (text & link)

I think it should be self-explained for how to set it up (just by adding new items to the arrays) but in case if not, just let me know.