### PR TITLE
Use a local FileProvider when sending icons back to an app.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -223,6 +223,17 @@
         <!--android:name=".zooper.TemplateProvider"-->
         <!--android:authorities="com.afollestad.polar.zwprovider"/>-->
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.iconFileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true"
+            >
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/afollestad/polar/fragments/IconsFragment.java
+++ b/app/src/main/java/com/afollestad/polar/fragments/IconsFragment.java
@@ -8,9 +8,9 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.Nullable;
+import android.support.v4.content.FileProvider;
 import android.support.v4.content.res.ResourcesCompat;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -25,13 +25,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.widget.TextView;
-import android.widget.Toast;
 
-import com.afollestad.assent.Assent;
-import com.afollestad.assent.AssentCallback;
-import com.afollestad.assent.PermissionResultSet;
 import com.afollestad.bridge.BridgeUtil;
 import com.afollestad.materialdialogs.util.DialogUtils;
+import com.afollestad.polar.BuildConfig;
 import com.afollestad.polar.R;
 import com.afollestad.polar.adapters.IconAdapter;
 import com.afollestad.polar.config.Config;
@@ -60,10 +57,6 @@ public class IconsFragment extends BasePageFragment implements
     public IconsFragment() {
     }
 
-    private static Activity mContext;
-    private static Fragment mContext2;
-    private static DrawableXmlParser.Icon mIcon;
-
     public static IconsFragment create(boolean selectionMode) {
         IconsFragment frag = new IconsFragment();
         Bundle args = new Bundle();
@@ -83,40 +76,26 @@ public class IconsFragment extends BasePageFragment implements
             return;
         }
         if (context instanceof ISelectionMode && ((ISelectionMode) context).inSelectionMode()) {
-            if (!Assent.isPermissionGranted(Assent.WRITE_EXTERNAL_STORAGE)) {
-                mContext = context;
-                mContext2 = context2;
-                mIcon = icon;
-                Assent.requestPermissions(new AssentCallback() {
-                    @Override
-                    public void onPermissionResult(PermissionResultSet permissionResultSet) {
-                        if (permissionResultSet.allPermissionsGranted())
-                            selectItem(mContext, mContext2, mIcon);
-                        else
-                            Toast.makeText(context, R.string.write_storage_permission_denied, Toast.LENGTH_LONG).show();
-                        mContext = null;
-                        mContext2 = null;
-                        mIcon = null;
-                    }
-                }, 79, Assent.WRITE_EXTERNAL_STORAGE);
-                return;
-            }
-
             final ProgressDialogFragment progress = ProgressDialogFragment.show((AppCompatActivity) context, R.string.please_wait);
             new Thread(new Runnable() {
                 @Override
                 public void run() {
-                    File dest = new File(Environment.getExternalStorageDirectory(), "IconCache");
+                    File dest = context.getCacheDir();
                     dest.mkdirs();
                     dest = new File(dest, icon.getName() + ".png");
                     FileOutputStream os = null;
                     try {
                         os = new FileOutputStream(dest);
                         bmp.compress(Bitmap.CompressFormat.PNG, 100, os);
-                        final Uri uri = Uri.fromFile(dest);
+
+                        Uri uri = FileProvider.getUriForFile(
+                                context,
+                                BuildConfig.APPLICATION_ID + ".iconFileProvider",
+                                dest);
                         context.setResult(Activity.RESULT_OK, new Intent()
                                 .putExtra(Intent.EXTRA_STREAM, uri)
-                                .setData(uri));
+                                .setData(uri)
+                                .setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION));
                         context.finish();
                     } catch (final Exception e) {
                         dest.delete();

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="IconCache"  path="/"/>
+</paths>


### PR DESCRIPTION
This way Polar doesn't need to ask for Storage Permission just for sending a file to another app.

Ideally this method could be also used in other Polar areas, like aplying wallpapers or sending the icon requests.