### PR TITLE
Added support for Kustom Widget (KWGT) and Kustom Wallpaper (KLWP) tabs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         applicationId "com.afollestad.polar"
-        minSdkVersion 17
+        minSdkVersion 19
         targetSdkVersion TARGET_SDK
         versionCode 28
         versionName "1.7.0"
@@ -94,4 +94,6 @@ dependencies {
 
     compile 'com.anjlab.android.iab.v3:library:1.0.32'
     compile 'com.pluscubed:insets-dispatcher:0.1.3'
+
+    compile 'org.bitbucket.frankmonza:kustomapi:+'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -225,6 +225,25 @@
             android:label="@string/app_name_wallpaper"
             android:theme="@style/AppTheme.Viewer" />
 
+        <!-- TODO: Uncomment next lines for Kustom -->
+        <!--
+        <provider
+            android:name="org.kustom.api.Provider"
+            android:authorities="${applicationId}.kustomprovider"
+            android:exported="true"
+            tools:ignore="ExportedContentProvider">
+            <intent-filter> -->
+                <!-- TODO Uncomment this if you are going to provide Wallpapers -->
+                <!-- <action android:name="org.kustom.provider.WALLPAPERS" /> -->
+                <!-- TODO Uncomment this if you are going to provide Widgets -->
+                <!-- <action android:name="org.kustom.provider.WIDGETS" /> -->
+                <!-- TODO Uncomment this if you are going to provide Komponents -->
+                <!-- <action android:name="org.kustom.provider.KOMPONENTS" /> -->
+        <!-- TODO: Uncomment next lines for Kustom -->
+        <!--
+            </intent-filter>
+        </provider> -->
+
         <!-- TODO: Uncomment next three lines for Zooper -->
         <!--<provider-->
         <!--android:name=".zooper.TemplateProvider"-->

--- a/app/src/main/java/com/afollestad/polar/adapters/KustomAdapter.java
+++ b/app/src/main/java/com/afollestad/polar/adapters/KustomAdapter.java
@@ -1,0 +1,182 @@
+package com.afollestad.polar.adapters;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.CardView;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.afollestad.polar.R;
+import com.afollestad.polar.fragments.KustomFragment;
+import com.afollestad.polar.kustom.KustomUtil;
+import com.afollestad.polar.util.Utils;
+import com.bumptech.glide.Glide;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Locale;
+
+import butterknife.ButterKnife;
+
+/**
+ * @author Frank Monza (fmonza)
+ */
+public class KustomAdapter extends RecyclerView.Adapter<KustomAdapter.KustomVH> {
+
+    private final static String GOOGLE_PLAY_URL = "https://play.google.com/store/apps/details?id=%s";
+
+    public final static int SEARCH_RESULT_LIMIT = 10;
+
+    private final Object LOCK = new Object();
+
+    private final boolean mKustomInstalled;
+    private final String mFolder;
+
+    private Drawable mWallpaper;
+    private ArrayList<KustomFragment.PreviewItem> mPreviews;
+    private ArrayList<KustomFragment.PreviewItem> mPreviewsFiltered;
+
+    public KustomAdapter(Context context, final @NonNull @KustomUtil.KustomDir String folder) {
+        mFolder = folder;
+        mKustomInstalled = Utils.isPkgInstalled(context, KustomUtil.getPkgByFolder(folder));
+    }
+
+    public void setPreviews(ArrayList<KustomFragment.PreviewItem> previewFiles, Drawable wallpaper) {
+        this.mPreviews = previewFiles;
+        this.mWallpaper = wallpaper;
+        notifyDataSetChanged();
+    }
+
+    public void filter(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            synchronized (LOCK) {
+                if (mPreviewsFiltered != null) {
+                    mPreviewsFiltered.clear();
+                    mPreviewsFiltered = null;
+                }
+            }
+        }
+        else {
+            synchronized (LOCK) {
+                mPreviewsFiltered = new ArrayList<>();
+                name = name.toLowerCase(Locale.getDefault());
+                for (int i = 0; i < mPreviews.size(); i++) {
+                    if (mPreviewsFiltered.size() == SEARCH_RESULT_LIMIT)
+                        break;
+                    if (mPreviews.get(i).title
+                            .toLowerCase(Locale.getDefault())
+                            .contains(name)) {
+                        mPreviewsFiltered.add(mPreviews.get(i));
+                    }
+                }
+                if (mPreviewsFiltered.size() == 0) {
+                    mPreviewsFiltered = null;
+                }
+            }
+        }
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        if (position == 0 && !mKustomInstalled)
+            return 1;
+        return 0;
+    }
+
+    @Override
+    public KustomVH onCreateViewHolder(ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(viewType == 1 ?
+                R.layout.list_item_kustom_header : R.layout.list_item_kustom, parent, false);
+        return new KustomVH(view, mFolder, viewType == 1);
+    }
+
+    @Override
+    public void onBindViewHolder(KustomVH holder, int position) {
+        if (holder.image != null) {
+            if (getItemViewType(0) == 1) position--;
+            final KustomFragment.PreviewItem preview = mPreviewsFiltered != null ?
+                    mPreviewsFiltered.get(position) : mPreviews.get(position);
+            Glide.with(holder.itemView.getContext())
+                    .load(new File(preview.previewPath))
+                    .into(holder.image);
+            holder.background.setImageDrawable(mWallpaper);
+            holder.name.setText(preview.title);
+            holder.file = preview.fileName;
+        } else {
+            StaggeredGridLayoutManager.LayoutParams lp = (StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams();
+            lp.setFullSpan(true);
+            holder.itemView.setLayoutParams(lp);
+        }
+        if (holder.title != null) {
+            holder.title.setText(KustomUtil.getInstallMsg(KustomUtil.getPkgByFolder(mFolder)));
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        if (mPreviewsFiltered != null)
+            return mPreviewsFiltered.size() + (!mKustomInstalled ? 1 : 0);
+        else if (mPreviews != null && mPreviews.size() > 0)
+            return mPreviews.size() + (!mKustomInstalled ? 1 : 0);
+        else return 0;
+    }
+
+    public static class KustomVH extends RecyclerView.ViewHolder implements View.OnClickListener {
+        final String folder;
+        String file;
+        final boolean showInstaller;
+        final ImageView background;
+        final ImageView image;
+        final TextView name;
+        final TextView title;
+        final CardView card;
+
+        public KustomVH(View itemView, @NonNull String folder, boolean showInstaller) {
+            super(itemView);
+            this.folder = folder;
+            this.showInstaller = showInstaller;
+            background = ButterKnife.findById(itemView, R.id.background);
+            image = ButterKnife.findById(itemView, R.id.image);
+            name = ButterKnife.findById(itemView, R.id.name);
+            card = ButterKnife.findById(itemView, R.id.card);
+            title = ButterKnife.findById(itemView, R.id.title);
+            card.setOnClickListener(this);
+        }
+
+        @Override
+        public void onClick(View view) {
+            final Context c = view.getContext();
+            if (showInstaller) {
+                String pkg = KustomUtil.getPkgByFolder(folder);
+                if (!Utils.isPkgInstalled(c, pkg)) {
+                    Toast.makeText(c, R.string.kustom_already_installed, Toast.LENGTH_SHORT).show();
+                } else {
+                    c.startActivity(new Intent(Intent.ACTION_VIEW)
+                            .setData(Uri.parse(String.format(GOOGLE_PLAY_URL, pkg))));
+                }
+            } else {
+                Intent i = new Intent();
+                i.setComponent(new ComponentName(KustomUtil.getPkgByFolder(folder),
+                        KustomUtil.getEditorActivityByFolder(folder)));
+                i.setData(new Uri.Builder()
+                        .scheme("kfile")
+                        .authority(String.format("%s.kustomprovider", c.getPackageName()))
+                        .appendPath(folder)
+                        .appendPath(file)
+                        .build());
+                c.startActivity(i);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/afollestad/polar/config/Config.java
+++ b/app/src/main/java/com/afollestad/polar/config/Config.java
@@ -129,6 +129,16 @@ public class Config implements IConfig {
         return mR != null && mR.getBoolean(R.bool.enable_zooper_page);
     }
 
+    @Override
+    public boolean kustomWidgetEnabled() {
+        return mR != null && mR.getBoolean(R.bool.enable_kustom_widgets_page);
+    }
+
+    @Override
+    public boolean kustomWallpaperEnabled() {
+        return mR != null && mR.getBoolean(R.bool.enable_kustom_wallpapers_page);
+    }
+
     @Nullable
     @Override
     public String iconRequestEmail() {
@@ -234,6 +244,12 @@ public class Config implements IConfig {
     public int gridWidthZooper() {
         if (mR == null) return 2;
         return mR.getInteger(R.integer.zooper_grid_width);
+    }
+
+    @Override
+    public int gridWidthKustom() {
+        if (mR == null) return 2;
+        return mR.getInteger(R.integer.kustom_grid_width);
     }
 
     @Override

--- a/app/src/main/java/com/afollestad/polar/config/IConfig.java
+++ b/app/src/main/java/com/afollestad/polar/config/IConfig.java
@@ -32,6 +32,10 @@ public interface IConfig {
 
     boolean zooperEnabled();
 
+    boolean kustomWidgetEnabled();
+
+    boolean kustomWallpaperEnabled();
+
     @Nullable
     String iconRequestEmail();
 
@@ -72,6 +76,8 @@ public interface IConfig {
     int gridWidthRequests();
 
     int gridWidthZooper();
+
+    int gridWidthKustom();
 
     int iconRequestMaxCount();
 

--- a/app/src/main/java/com/afollestad/polar/fragments/KustomFragment.java
+++ b/app/src/main/java/com/afollestad/polar/fragments/KustomFragment.java
@@ -1,0 +1,221 @@
+package com.afollestad.polar.fragments;
+
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.view.MenuItemCompat;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SearchView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.widget.TextView;
+
+import com.afollestad.materialdialogs.util.DialogUtils;
+import com.afollestad.polar.R;
+import com.afollestad.polar.adapters.KustomAdapter;
+import com.afollestad.polar.config.Config;
+import com.afollestad.polar.fragments.base.BasePageFragment;
+import com.afollestad.polar.kustom.KustomUtil;
+import com.afollestad.polar.ui.MainActivity;
+import com.afollestad.polar.util.TintUtils;
+import com.afollestad.polar.util.Utils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.Unbinder;
+
+/**
+ * @author Frank Monza (fmonza)
+ */
+public class KustomFragment extends BasePageFragment implements
+        SearchView.OnQueryTextListener, SearchView.OnCloseListener {
+
+    public static String ARG_FOLDER = "folder";
+
+    @BindView(android.R.id.list)
+    RecyclerView mRecyclerView;
+    @BindView(android.R.id.empty)
+    TextView mEmpty;
+    @BindView(android.R.id.progress)
+    View mProgress;
+
+    private KustomAdapter mAdapter;
+    private String mQueryText;
+    private final Runnable searchRunnable = new Runnable() {
+        @Override
+        public void run() {
+            mAdapter.filter(mQueryText);
+            setListShown(true);
+        }
+    };
+    private ArrayList<PreviewItem> mPreviews;
+    private Drawable mWallpaper;
+    private Unbinder unbinder;
+
+    public KustomFragment() {
+    }
+
+    public static KustomFragment newInstance(@KustomUtil.KustomDir String folder) {
+        KustomFragment myFragment = new KustomFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_FOLDER, folder);
+        myFragment.setArguments(args);
+        return myFragment;
+    }
+
+    @Override
+    public int getTitle() {
+        if (KustomUtil.FOLDER_WIDGETS.equals(getFolder()))
+            return R.string.kwgt;
+        else return R.string.klwp;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_recyclerview, container, false);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.kustom, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+        MenuItem mSearchItem = menu.findItem(R.id.search);
+        SearchView mSearchView = (SearchView) MenuItemCompat.getActionView(mSearchItem);
+        mSearchView.setQueryHint(getString(getSearchHintRes()));
+        mSearchView.setOnQueryTextListener(this);
+        mSearchView.setOnCloseListener(this);
+        mSearchView.setImeOptions(EditorInfo.IME_ACTION_DONE);
+
+        if (getActivity() != null) {
+            final MainActivity act = (MainActivity) getActivity();
+            TintUtils.themeSearchView(act.getToolbar(), mSearchView, DialogUtils.resolveColor(act, R.attr.tab_icon_color));
+        }
+    }
+
+    private void setListShown(boolean shown) {
+        final View v = getView();
+        if (v != null) {
+            mRecyclerView.setVisibility(shown ?
+                    View.VISIBLE : View.GONE);
+            mProgress.setVisibility(shown ?
+                    View.GONE : View.VISIBLE);
+            mEmpty.setVisibility(shown && mAdapter.getItemCount() == 0 ?
+                    View.VISIBLE : View.GONE);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "WrongConstant"})
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        unbinder = ButterKnife.bind(this, view);
+
+        final int kustomGridWidth = Config.get().gridWidthKustom();
+        mAdapter = new KustomAdapter(getActivity(), getFolder());
+        mRecyclerView.setLayoutManager(new StaggeredGridLayoutManager(
+                kustomGridWidth, StaggeredGridLayoutManager.VERTICAL));
+        mRecyclerView.setAdapter(mAdapter);
+
+        KustomUtil.getPreviews(getActivity(), new KustomUtil.PreviewCallback() {
+            @Override
+            public void onPreviewsLoaded(ArrayList<PreviewItem> previews, Drawable wallpaper, Exception error) {
+                if (getActivity() == null || getActivity().isFinishing() || !isAdded())
+                    return;
+                else if (error != null) {
+                    error.printStackTrace();
+                    setListShown(true);
+                    mAdapter.setPreviews(null, null);
+                    mEmpty.setVisibility(View.VISIBLE);
+                    if (error.getMessage().trim().isEmpty())
+                        mEmpty.setText(error.toString());
+                    else mEmpty.setText(error.getMessage());
+                    return;
+                }
+                mPreviews = previews;
+                mWallpaper = wallpaper;
+                mAdapter.setPreviews(mPreviews, mWallpaper);
+            }
+        }, getFolder());
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (getActivity() != null && getActivity().isFinishing()) {
+            Utils.wipe(KustomUtil.getKustomPreviewCache(getActivity()));
+            mWallpaper = null;
+            mPreviews = null;
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
+    }
+
+    @Override
+    public boolean onQueryTextSubmit(String query) {
+        return false;
+    }
+
+    @Override
+    public boolean onQueryTextChange(String newText) {
+        mQueryText = newText;
+        mRecyclerView.postDelayed(searchRunnable, 400);
+        return false;
+    }
+
+    @Override
+    public boolean onClose() {
+        mRecyclerView.removeCallbacks(searchRunnable);
+        mQueryText = null;
+        mAdapter.filter(null);
+        setListShown(true);
+        return false;
+    }
+
+    private int getSearchHintRes() {
+        if (KustomUtil.FOLDER_WIDGETS.equals(getFolder())) {
+            return R.string.search_widgets;
+        } else return R.string.search_wallpapers;
+    }
+
+    private String getFolder() {
+        return getArguments().getString(ARG_FOLDER);
+    }
+
+    public static class PreviewItem implements Serializable {
+        public final String folder;
+        public final String fileName;
+        public final String previewPath;
+        public final String title;
+
+        public PreviewItem(JSONObject info, String folder, String fileName, String previewPath)
+                throws JSONException {
+            this.folder = folder;
+            this.fileName = fileName;
+            this.previewPath = previewPath;
+            this.title = info.getString("title");
+        }
+
+    }
+}

--- a/app/src/main/java/com/afollestad/polar/kustom/KustomUtil.java
+++ b/app/src/main/java/com/afollestad/polar/kustom/KustomUtil.java
@@ -1,0 +1,201 @@
+package com.afollestad.polar.kustom;
+
+import android.app.Activity;
+import android.app.WallpaperManager;
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringDef;
+import android.support.annotation.StringRes;
+
+import com.afollestad.bridge.BridgeUtil;
+import com.afollestad.polar.R;
+import com.afollestad.polar.fragments.KustomFragment;
+import com.afollestad.polar.util.Utils;
+
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * @author Frank Monza (fmonza)
+ */
+public class KustomUtil {
+
+    public static final String FOLDER_WALLPAPERS = "wallpapers";
+    public static final String FOLDER_WIDGETS = "widgets";
+
+    private final static String PKG_KLWP = "org.kustom.wallpaper";
+    private final static String PKG_KWGT = "org.kustom.widget";
+
+    private final static String EDITOR_KLWP = "org.kustom.lib.editor.WpAdvancedEditorActivity";
+    private final static String EDITOR_KWGT = "org.kustom.widget.picker.WidgetPicker";
+
+
+    private KustomUtil() {
+    }
+
+    @StringRes
+    public static int getInstallMsg(String pkg) {
+        if (PKG_KWGT.equals(pkg)) return R.string.made_for_kwgt;
+        return R.string.made_for_klwp;
+    }
+
+    public static String getPkgByFolder(@NonNull @KustomDir String folder) {
+        return FOLDER_WIDGETS.equals(folder) ? PKG_KWGT : PKG_KLWP;
+    }
+
+    public static String getEditorActivityByFolder(@NonNull @KustomDir String folder) {
+        return FOLDER_WIDGETS.equals(folder) ? EDITOR_KWGT : EDITOR_KLWP;
+    }
+
+    private static void post(@Nullable Activity target, @NonNull Runnable runnable) {
+        if (target == null || target.isFinishing()) return;
+        target.runOnUiThread(runnable);
+    }
+
+    public static File getKustomPreviewCache(@NonNull Context context) {
+        return new File(context.getExternalCacheDir(), "KustomPreviews");
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public static void getPreviews(final Activity context, final PreviewCallback cb, final @NonNull @KustomDir String folder) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    final AssetManager am = context.getAssets();
+                    final String[] templates = am.list(folder);
+
+                    if (templates == null || templates.length == 0) {
+                        post(context, new Runnable() {
+                            @Override
+                            public void run() {
+                                cb.onPreviewsLoaded(null, null, null);
+                            }
+                        });
+                        return;
+                    }
+
+                    final File cacheDir = getKustomPreviewCache(context);
+                    Utils.wipe(cacheDir);
+                    cacheDir.mkdirs();
+                    final ArrayList<KustomFragment.PreviewItem> results = new ArrayList<>();
+
+                    for (String file : templates) {
+                        final File kFileCache = new File(cacheDir, file);
+                        InputStream is = null;
+                        OutputStream os = null;
+                        try {
+                            is = am.open(folder + "/" + file);
+                            os = new FileOutputStream(kFileCache);
+                            Utils.copy(is, os);
+                            BridgeUtil.closeQuietly(is);
+                            BridgeUtil.closeQuietly(os);
+
+                            if (kFileCache.exists()) {
+                                final String widgetName = Utils.removeExtension(kFileCache.getName());
+                                final ZipFile zipFile = new ZipFile(kFileCache);
+                                final Enumeration<? extends ZipEntry> entryEnum = zipFile.entries();
+                                JSONObject info = null;
+                                File webpFile = null;
+                                ZipEntry entry;
+                                while ((entry = entryEnum.nextElement()) != null) {
+                                    if (entry.getName().endsWith("preset_thumb_portrait.jpg")) {
+                                        webpFile = new File(cacheDir, widgetName + ".webp");
+                                        InputStream zis = null;
+                                        OutputStream pos = null;
+                                        try {
+                                            zis = zipFile.getInputStream(entry);
+                                            pos = new FileOutputStream(webpFile);
+                                            Utils.copy(zis, pos);
+                                        } finally {
+                                            BridgeUtil.closeQuietly(zis);
+                                            BridgeUtil.closeQuietly(pos);
+                                        }
+                                    }
+                                    if (entry.getName().endsWith("preset.json")) {
+                                        InputStream zis = null;
+                                        try {
+                                            zis = zipFile.getInputStream(entry);
+                                            BufferedReader streamReader = new BufferedReader(new InputStreamReader(zis, "UTF-8"));
+                                            StringBuilder responseStrBuilder = new StringBuilder();
+                                            String inputStr;
+                                            while ((inputStr = streamReader.readLine()) != null)
+                                                responseStrBuilder.append(inputStr);
+                                            JSONObject preset = new JSONObject(responseStrBuilder.toString());
+                                            info = preset.getJSONObject("preset_info");
+                                        } finally {
+                                            BridgeUtil.closeQuietly(zis);
+                                            BridgeUtil.closeQuietly(os);
+                                        }
+                                    }
+                                    if (info != null && webpFile != null) {
+                                        results.add(new KustomFragment.PreviewItem(info, folder,
+                                                kFileCache.getName(), webpFile.getAbsolutePath()));
+                                        break;
+                                    }
+                                }
+                            }
+                        } catch (final Exception e) {
+                            if (cb != null) {
+                                post(context, new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        cb.onPreviewsLoaded(null, null, e);
+                                    }
+                                });
+                            }
+                            break;
+                        } finally {
+                            kFileCache.delete();
+                            BridgeUtil.closeQuietly(is);
+                            BridgeUtil.closeQuietly(os);
+                        }
+                    }
+
+                    if (cb != null) {
+                        final Drawable wallpaperDrawable = WallpaperManager.getInstance(context).getDrawable();
+                        post(context, new Runnable() {
+                            @Override
+                            public void run() {
+                                cb.onPreviewsLoaded(results, wallpaperDrawable, null);
+                            }
+                        });
+                    }
+                } catch (final Exception e) {
+                    if (cb != null) {
+                        post(context, new Runnable() {
+                            @Override
+                            public void run() {
+                                cb.onPreviewsLoaded(null, null, e);
+                            }
+                        });
+                    }
+                }
+            }
+        }).start();
+    }
+
+    @StringDef({FOLDER_WALLPAPERS, FOLDER_WIDGETS})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface KustomDir {
+    }
+
+    public interface PreviewCallback {
+        void onPreviewsLoaded(ArrayList<KustomFragment.PreviewItem> previews, Drawable wallpaper, Exception error);
+    }
+}

--- a/app/src/main/java/com/afollestad/polar/ui/MainActivity.java
+++ b/app/src/main/java/com/afollestad/polar/ui/MainActivity.java
@@ -46,10 +46,12 @@ import com.afollestad.polar.fragments.AboutFragment;
 import com.afollestad.polar.fragments.ApplyFragment;
 import com.afollestad.polar.fragments.HomeFragment;
 import com.afollestad.polar.fragments.IconsFragment;
+import com.afollestad.polar.fragments.KustomFragment;
 import com.afollestad.polar.fragments.RequestsFragment;
 import com.afollestad.polar.fragments.WallpapersFragment;
 import com.afollestad.polar.fragments.ZooperFragment;
 import com.afollestad.polar.fragments.base.BasePageFragment;
+import com.afollestad.polar.kustom.KustomUtil;
 import com.afollestad.polar.ui.base.BaseDonateActivity;
 import com.afollestad.polar.util.DrawableXmlParser;
 import com.afollestad.polar.util.LicensingUtils;
@@ -193,6 +195,10 @@ public class MainActivity extends BaseDonateActivity implements
         if (Config.get().iconRequestEnabled())
             mPages.add(new PagesBuilder.Page(R.id.drawer_requestIcons, R.drawable.tab_requests, R.string.request_icons, new RequestsFragment()));
         mPages.add(new PagesBuilder.Page(R.id.drawer_apply, R.drawable.tab_apply, R.string.apply, new ApplyFragment()));
+        if (Config.get().kustomWidgetEnabled())
+            mPages.add(new PagesBuilder.Page(R.id.drawer_kwgt, R.drawable.tab_kwgt, R.string.kwgt, KustomFragment.newInstance(KustomUtil.FOLDER_WIDGETS)));
+        if (Config.get().kustomWallpaperEnabled())
+            mPages.add(new PagesBuilder.Page(R.id.drawer_klwp, R.drawable.tab_klwp, R.string.klwp, KustomFragment.newInstance(KustomUtil.FOLDER_WALLPAPERS)));
         if (Config.get().zooperEnabled())
             mPages.add(new PagesBuilder.Page(R.id.drawer_zooper, R.drawable.tab_zooper, R.string.zooper, new ZooperFragment()));
         mPages.add(new PagesBuilder.Page(R.id.drawer_about, R.drawable.tab_about, R.string.about, new AboutFragment()));

--- a/app/src/main/res/drawable/ic_action_kustom.xml
+++ b/app/src/main/res/drawable/ic_action_kustom.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="1300.0"
+    android:viewportWidth="1300.0">
+    <path
+        android:fillColor="#9b9d9f"
+        android:pathData="m-26.4,1620.3l1350.2,0c0,0 0,0 0,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0c0,0 -0,0 -0,0" />
+    <path
+        android:fillColor="#424242"
+        android:pathData="m985,140.3l-0.9,178.1l-70,0.5c-14,0 -25.5,11.4 -25.7,25.4l-1.7,176.9c-0.4,45.9 -15.6,88.4 -40.8,123.2c24.5,34.8 38.8,77.2 38.4,123.2l-1.8,176.8c-0.1,14 11.1,25.4 25.1,25.4l73.6,0l-0.9,178.5l-74.5,0c-117.1,0 -211.4,-95.2 -210.2,-212.3l1.8,-176.9c0.1,-14 -11.1,-25.3 -25.2,-25.3l-63.3,0l0.4,-89.5l-0.4,-89.2l65,-0.3c14.1,0 25.5,-11.4 25.7,-25.4l1.7,-176.8c1.1,-117 97.3,-212.3 214.4,-212.3l69.2,0z" />
+    <path
+        android:fillColor="#424242"
+        android:pathData="m493.1,1144.6l-180.8,0l0,-1003.6l180.8,0l0,1003.6z" />
+</vector>

--- a/app/src/main/res/drawable/tab_klwp.xml
+++ b/app/src/main/res/drawable/tab_klwp.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="1300.0"
+    android:viewportWidth="1300.0">
+    <path
+        android:fillColor="#ddd"
+        android:pathData="m-26.4,1620.3l1350.2,0c0,0 0,0 0,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0c0,0 -0,0 -0,0" />
+    <path
+        android:fillColor="#fff"
+        android:pathData="m985,140.3l-0.9,178.1l-70,0.5c-14,0 -25.5,11.4 -25.7,25.4l-1.7,176.9c-0.4,45.9 -15.6,88.4 -40.8,123.2c24.5,34.8 38.8,77.2 38.4,123.2l-1.8,176.8c-0.1,14 11.1,25.4 25.1,25.4l73.6,0l-0.9,178.5l-74.5,0c-117.1,0 -211.4,-95.2 -210.2,-212.3l1.8,-176.9c0.1,-14 -11.1,-25.3 -25.2,-25.3l-63.3,0l0.4,-89.5l-0.4,-89.2l65,-0.3c14.1,0 25.5,-11.4 25.7,-25.4l1.7,-176.8c1.1,-117 97.3,-212.3 214.4,-212.3l69.2,0z" />
+    <path
+        android:fillColor="#fff"
+        android:pathData="m493.1,1144.6l-180.8,0l0,-1003.6l180.8,0l0,1003.6z" />
+</vector>

--- a/app/src/main/res/drawable/tab_kwgt.xml
+++ b/app/src/main/res/drawable/tab_kwgt.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="1300.0"
+    android:viewportWidth="1300.0">
+    <path
+        android:fillColor="#ddd"
+        android:pathData="m-26.4,1620.3l1350.2,0c0,0 0,0 0,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0l-135,0c0,0 -0,0 -0,0" />
+    <path
+        android:fillColor="#fff"
+        android:pathData="m985,140.3l-0.9,178.1l-70,0.5c-14,0 -25.5,11.4 -25.7,25.4l-1.7,176.9c-0.4,45.9 -15.6,88.4 -40.8,123.2c24.5,34.8 38.8,77.2 38.4,123.2l-1.8,176.8c-0.1,14 11.1,25.4 25.1,25.4l73.6,0l-0.9,178.5l-74.5,0c-117.1,0 -211.4,-95.2 -210.2,-212.3l1.8,-176.9c0.1,-14 -11.1,-25.3 -25.2,-25.3l-63.3,0l0.4,-89.5l-0.4,-89.2l65,-0.3c14.1,0 25.5,-11.4 25.7,-25.4l1.7,-176.8c1.1,-117 97.3,-212.3 214.4,-212.3l69.2,0z" />
+    <path
+        android:fillColor="#fff"
+        android:pathData="m493.1,1144.6l-180.8,0l0,-1003.6l180.8,0l0,1003.6z" />
+</vector>

--- a/app/src/main/res/layout/list_item_kustom.xml
+++ b/app/src/main/res/layout/list_item_kustom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    tools:layout_marginTop="24dp">
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/card"
+        style="@style/Card">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            tools:ignore="ContentDescription">
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <com.afollestad.polar.views.SquareImageView
+                    android:id="@+id/background"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop" />
+
+                <com.afollestad.polar.views.SquareImageView
+                    android:id="@+id/image"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_margin="@dimen/content_inset"
+                    android:scaleType="centerInside" />
+
+            </FrameLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:minHeight="48dp"
+                android:orientation="vertical"
+                android:paddingBottom="@dimen/content_inset_half_card"
+                android:paddingLeft="@dimen/content_inset"
+                android:paddingRight="@dimen/content_inset"
+                android:paddingTop="@dimen/content_inset_half">
+
+                <TextView
+                    android:id="@+id/name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="sans-serif-medium"
+                    android:textColor="?android:textColorPrimary"
+                    android:textSize="@dimen/title_text_size"
+                    tools:text="Name" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </android.support.v7.widget.CardView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/list_item_kustom_header.xml
+++ b/app/src/main/res/layout/list_item_kustom_header.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:layout_marginTop="24dp">
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/card"
+        style="@style/Card"
+        android:layout_gravity="center"
+        android:layout_marginLeft="@dimen/card_sides_margin"
+        android:layout_marginRight="@dimen/card_sides_margin"
+        android:clickable="true"
+        android:foreground="?selectableItemBackground">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical|start"
+            android:minHeight="@dimen/quickapply_card_minheight"
+            android:orientation="horizontal"
+            android:paddingLeft="@dimen/content_inset_half"
+            android:paddingRight="@dimen/content_inset_half"
+            tools:ignore="UseCompoundDrawables">
+
+            <ImageView
+                android:id="@+id/icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/content_inset_half"
+                app:srcCompat="@drawable/ic_action_kustom"
+                tools:ignore="ContentDescription" />
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:textColor="?android:textColorSecondary"
+                android:textSize="@dimen/content_text_size"
+                tools:ignore="UnusedAttribute" />
+
+        </LinearLayout>
+
+    </android.support.v7.widget.CardView>
+
+</FrameLayout>

--- a/app/src/main/res/menu/kustom.xml
+++ b/app/src/main/res/menu/kustom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/search"
+        android:icon="@drawable/ic_action_search"
+        android:title="@string/search"
+        app:actionViewClass="android.support.v7.widget.SearchView"
+        app:showAsAction="ifRoom|collapseActionView" />
+
+</menu>

--- a/app/src/main/res/values-land/integers.xml
+++ b/app/src/main/res/values-land/integers.xml
@@ -6,5 +6,6 @@
     <integer name="icon_grid_width">6</integer>
     <integer name="requests_grid_width">5</integer>
     <integer name="zooper_grid_width">3</integer>
+    <integer name="kustom_grid_width">3</integer>
 
 </resources>

--- a/app/src/main/res/values-sw600dp-land/integers.xml
+++ b/app/src/main/res/values-sw600dp-land/integers.xml
@@ -6,5 +6,6 @@
     <integer name="icon_grid_width">6</integer>
     <integer name="requests_grid_width">4</integer>
     <integer name="zooper_grid_width">4</integer>
+    <integer name="kustom_grid_width">4</integer>
 
 </resources>

--- a/app/src/main/res/values-sw600dp/integers.xml
+++ b/app/src/main/res/values-sw600dp/integers.xml
@@ -6,5 +6,6 @@
     <integer name="icon_grid_width">6</integer>
     <integer name="requests_grid_width">4</integer>
     <integer name="zooper_grid_width">3</integer>
+    <integer name="kustom_grid_width">3</integer>
 
 </resources>

--- a/app/src/main/res/values-sw700dp-land/integers.xml
+++ b/app/src/main/res/values-sw700dp-land/integers.xml
@@ -6,5 +6,6 @@
     <integer name="icon_grid_width">8</integer>
     <integer name="requests_grid_width">6</integer>
     <integer name="zooper_grid_width">4</integer>
+    <integer name="kustom_grid_width">4</integer>
 
 </resources>

--- a/app/src/main/res/values/dev_kustom.xml
+++ b/app/src/main/res/values/dev_kustom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- This info is used in the available skins list in Zooper -->
+    <string name="kustom_pack_title">@string/app_name</string>
+    <string name="kustom_pack_description">Awesome Kustom powered by Polar</string>
+
+    <!-- Setting to true will display your Kustom Wallpaper templates within Polar -->
+    <bool name="enable_kustom_wallpapers_page">false</bool>
+
+    <!-- Setting to true will display your Kustom Widgets templates within Polar -->
+    <bool name="enable_kustom_widgets_page">false</bool>
+
+</resources>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -6,6 +6,8 @@
     <item name="drawer_wallpapers" type="id" />
     <item name="drawer_requestIcons" type="id" />
     <item name="drawer_apply" type="id" />
+    <item name="drawer_kwgt" type="id" />
+    <item name="drawer_klwp" type="id" />
     <item name="drawer_zooper" type="id" />
     <item name="drawer_about" type="id" />
 

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -7,5 +7,6 @@
     <integer name="font_textStyle_medium">1</integer>
     <integer name="requests_grid_width">3</integer>
     <integer name="zooper_grid_width">2</integer>
+    <integer name="kustom_grid_width">2</integer>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="changelog" translatable="false">Changelog</string>
     <string name="error">Error</string>
     <string name="search_icons">Search icons…</string>
+    <string name="search">Search</string>
     <string name="no_results">No results</string>
     <string name="about">About</string>
     <string name="request_icons">Request Icons</string>
@@ -65,6 +66,8 @@
     <string name="home">Home</string>
     <string name="nav_drawer_mode">Nav drawer mode</string>
     <string name="zooper">Zooper</string>
+    <string name="klwp">KLWP</string>
+    <string name="kwgt">KWGT</string>
     <string name="permission_needed">Permission Needed</string>
     <string name="permission_needed_zooper_desc"><![CDATA[ <b>%1$s</b> needs permission to access your phone\'s storage in order to save Zooper assets!]]></string>
     <string name="download_cancelled">Download cancelled!</string>
@@ -79,6 +82,9 @@
     <string name="search_widgets">Search widgets…</string>
     <string name="made_for_zooper">These widgets are made for Zooper Pro</string>
     <string name="zooper_already_installed">Zooper Pro is already installed!</string>
+    <string name="made_for_klwp">These wallpapers are made for Kustom Wallpaper PRO (KLWP)</string>
+    <string name="made_for_kwgt">These widgets are made for Kustom Widget PRO (KWGT)</string>
+    <string name="kustom_already_installed">Kustom is already installed!</string>
     <string name="assets_installed">Assets installed successfully!</string>
     <string name="please_wait">Please wait…</string>
     <string name="installing_fonts">Installing fonts…</string>


### PR DESCRIPTION
This pull adds support for Kustom Widget and Kustom Wallpaper tabs. Support is similar to Zooper, i will also fork gh-pages as soon as i have time and create the associated tutorial but main things to note are the following:

- Min SDK for Kustom is 19, i brought it to 19 in the merge but you can revert to 17 and put a comment stating that in case Kustom is in use 19 must be used
- Kustom provider is on a maven API pkg, pkg has been added to deps, i used a "+" but specific version can also be used (0.8)
- User just need to copy files in either assets/wallpapers or assets/widgets then enable the feature in "dev_kustom.xml" and finally uncomment the provider in the manifest

Behavior on click is different, Kustom is able to open the files directly in the editor, so when clicking presets user will be sent to the editor with that specific preset open, Kustom can also apply presets on the fly so we can also add a feature to apply the theme immediately (at least on KLWP) but i didnt know how to put that UI wise.