### PR TITLE
Fixed issues on some assets being compressed during build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,10 @@ android {
             shrinkResources false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        // Required by Kustom support to avoid assets being compressed
+        aaptOptions {
+            noCompress 'zip', 'komp', 'klwp', 'kwgt', 'klck', 'kwch'
+        }
     }
 }
 


### PR DESCRIPTION
This is an *URGENT* change due to the fact that some assets are compressed during build even if minify and shrink are disabled